### PR TITLE
Allow system user to set ril.* props

### DIFF
--- a/init/property_service.c
+++ b/init/property_service.c
@@ -72,6 +72,7 @@ struct {
     { "net.lte",          AID_RADIO,    0 },
     { "net.cdma",         AID_RADIO,    0 },
     { "ril.",             AID_RADIO,    0 },
+    { "ril.",             AID_SYSTEM,   0 },
     { "gsm.",             AID_RADIO,    0 },
     { "persist.radio",    AID_RADIO,    0 },
     { "net.dns",          AID_RADIO,    0 },
@@ -439,8 +440,8 @@ void handle_property_set_fd()
             if (check_perms(msg.name, cr.uid, cr.gid, source_ctx)) {
                 property_set((char*) msg.name, (char*) msg.value);
             } else {
-                ERROR("sys_prop: permission denied uid:%d  name:%s\n",
-                      cr.uid, msg.name);
+                ERROR("sys_prop: permission denied pid:%d uid:%d name:%s\n",
+                      cr.pid, cr.uid, msg.name);
             }
 
             // Note: bionic's property client code assumes that the

--- a/libcutils/properties.c
+++ b/libcutils/properties.c
@@ -15,6 +15,7 @@
  */
 
 #define LOG_TAG "properties"
+#define LOG_NDEBUG 0
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Some Samsung phone use phoneserver daemon to manage rild daemons.
Its default user to root but for some unknown reason dropped to system user and thus cannot set ril.* props.

Change-Id: Ie8296132145ea842b508f303bed0222176893d61